### PR TITLE
fix bug: upper limit does not work

### DIFF
--- a/src/jquery.spinner.js
+++ b/src/jquery.spinner.js
@@ -95,7 +95,12 @@
 
     numeric: function(v){
       v = this.options.precision > 0 ? parseFloat(v, 10) : parseInt(v, 10);
-      return v || this.options.min || 0;
+      // If the variable is a number
+      if (!isNaN(parseFloat(v)) && isFinite(v)) {
+    	  return v;
+      } else {
+    	  return v || this.options.min || 0; 
+      }
     },
 
     validate: function(val){


### PR DESCRIPTION
Description of the problem: 
for:  
    [input type = "text" data-max = "2" data-min = "- 2"]

can not be set any number between [0; 2]
