### PR TITLE
Moved spinningTimer to Spinning scope instead of global (shared) scope

### DIFF
--- a/js/jquery.spinner.js
+++ b/js/jquery.spinner.js
@@ -20,13 +20,13 @@
     factory(jQuery);
   }
 })(function($) {
-  var spinningTimer;
   var Spinner;
   var Spinning = function($element, options) {
     this.$el = $element;
     this.options = $.extend({}, Spinning.rules.defaults, Spinning.rules[options.rule] || {}, options);
     this.min = Number(this.options.min) || 0;
     this.max = Number(this.options.max) || 0;
+    this.spinningTimer = null;
 
     this.$el.on({
       'focus.spinner': $.proxy(function(e) {
@@ -99,8 +99,8 @@
         this.$el.trigger('changing.spinner', [this.value(), this.oldValue]);
 
         // lazy changed.spinner
-        clearTimeout(spinningTimer);
-        spinningTimer = setTimeout($.proxy(function() {
+        clearTimeout(this.spinningTimer);
+        this.spinningTimer = setTimeout($.proxy(function() {
           this.$el.trigger('changed.spinner', [this.value(), this.oldValue]);
         }, this), Spinner.delay);
       }


### PR DESCRIPTION
Let spinners have their own spinningTimer, instead of a shared one. This allows for individual AJAX requests to trigger on changed.spinner. For example, when tapping plus on individual spinners within a short period of time, both spinners will trigger changed.spinner, instead of only the last one. See screenshot.
![screenshot](https://user-images.githubusercontent.com/87523/40043869-0cea1e46-5826-11e8-9a5f-6c802bd5864f.png)
